### PR TITLE
Fixed wrong dependencies

### DIFF
--- a/zx120_description/package.xml
+++ b/zx120_description/package.xml
@@ -28,7 +28,7 @@
 	<exec_depend>rviz</exec_depend>
 	<exec_depend>xacro</exec_depend>
 	<depend>ros_control</depend>
-	<depend>ros_controller</depend>
+	<depend>ros_controllers</depend>
 	
 	<exec_depend>roboticsgroup_upatras_gazebo_plugins</exec_depend>
 

--- a/zx120_moveit_config/package.xml
+++ b/zx120_moveit_config/package.xml
@@ -29,7 +29,7 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
   <depend>ros_control</depend>
-  <depend>ros_controller</depend>
+  <depend>ros_controllers</depend>
   <depend>moveit_simple_controller_manager</depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
   <!-- <exec_depend>warehouse_ros_mongo</exec_depend> -->


### PR DESCRIPTION
package.xml内の脱字により、以下のようなエラーが返されていたので、修正いたしました。

```bash
zx120_description: Cannot locate rosdep definition for [ros_controller]
zx120_moveit_config: Cannot locate rosdep definition for [ros_controller]
```